### PR TITLE
chore: unpin podman container image digest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # https://github.com/containers/podman/tree/main/contrib/podmanimage
-      image: quay.io/containers/podman:v4.5.1@sha256:a9197f83e7c6b6abf4e17df52b4bfb4bab47231a4da2786300505ecb41f816bd
+      image: quay.io/containers/podman:v4.5.1
       options: >-
         --device /dev/fuse:rw
         --privileged

--- a/renovate.json
+++ b/renovate.json
@@ -51,10 +51,11 @@
       "allowedVersions": "<1"
     },
     {
-      "description": "Limit podman image digest to monthly (built daily)",
+      "description": "Disable pinning podman image digest",
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["container"],
       "matchPackageNames": ["quay.io/containers/podman"],
-      "matchUpdateTypes": ["digest"],
-      "extends": ["schedule:monthly"]
+      "pinDigests": false
     },
     {
       "matchDepTypes": ["require"],


### PR DESCRIPTION
Produces errors:

```
Error response from daemon: manifest for quay.io/containers/podman@sha256:a9197f83e7c6b6abf4e17df52b4bfb4bab47231a4da2786300505ecb41f816bd not found: manifest unknown: manifest unknown
```