### PR TITLE
revert: downgrade semantic-release-action to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,10 +150,10 @@ jobs:
           REGISTRY: ghcr.io
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@61680d0e9b02ff86f5648ade99e01be17f0260a4 # v4.0.0
+        uses: cycjimmy/semantic-release-action@8e58d20d0f6c8773181f43eb74d6a05e3099571d # v3.4.2
         with:
           # renovate: datasource=npm depName=semantic-release
-          semantic_version: 22.0.5
+          semantic_version: 19.0.5
           dry_run: ${{ github.event_name == 'pull_request' }}
           extra_plugins: |
             conventional-changelog-conventionalcommits@7.0.2


### PR DESCRIPTION
I suspect the upgrade to Node 20 (#480) does not play well with `podman` (`crun` specifically)